### PR TITLE
修正不带area请求被错误分流情况

### DIFF
--- a/utils/functions.php
+++ b/utils/functions.php
@@ -21,9 +21,6 @@ function get_webpage($url,$host="",$ip="") {
 			case "th":
 				curl_setopt($ch, CURLOPT_PROXY, PROXY_IP_TH);
 				break;
-			case "noarea":
-				curl_setopt($ch, CURLOPT_PROXY, PROXY_IP);
-				break;
 			default:
 				if ($host = CUSTOM_HOST_TH_TOKEN || $host = CUSTOM_HOST_TH_SEARCH || $host = CUSTOM_HOST_TH || $host = CUSTOM_HOST_TH_SUB) {
 					curl_setopt($ch, CURLOPT_PROXY, PROXY_IP_TH);


### PR DESCRIPTION
原代码case "noarea":似乎是多余的，实际上不带area会默认走default ip，而例如泰区sub不带area参数会被define成 noarea，被case "noarea":截获，会错误走PROXY_IP，而不会走default下的if（$host）的PROXY_IP_TH。if（$host）←等于这个实质上是失效的状态。